### PR TITLE
Fix Error: [] operator not supported for strings in ContentStagingJson.php line 112

### DIFF
--- a/src/Plugin/migrate/source/ContentStagingJson.php
+++ b/src/Plugin/migrate/source/ContentStagingJson.php
@@ -108,6 +108,7 @@ class ContentStagingJson extends SourcePluginBase {
       }
       elseif (is_scalar($item) || (count($item) != 1 && !isset($item['width']) && !isset($item['pid']))) {
         if (isset($item[0]) && isset($item[0]['target_uuid'])) {
+          $value = [];
           foreach ($item as $it) {
             $value[] = $it['target_uuid'];
           }


### PR DESCRIPTION
Initialize $value var to new array before foreach($item as $it) to avoid possible side effect of $value containing a string value