### PR TITLE
Fix potential crash when  passed to transform() is null on ContentStagingIterator

### DIFF
--- a/src/Plugin/migrate/process/ContentStagingIterator.php
+++ b/src/Plugin/migrate/process/ContentStagingIterator.php
@@ -22,7 +22,7 @@ class ContentStagingIterator extends Iterator {
    * Runs a process pipeline on each destination property per list item.
    */
   public function transform($value, MigrateExecutableInterface $migrate_executable, Row $row, $destination_property) {
-    if (!is_array($value[0])) {
+    if (isset($value) && !is_array($value[0])) {
       $new_value = [$value];
     }
     else {


### PR DESCRIPTION
If the $value is null, it should not be put in an array and passed as is (so as null) to the parent::transform() method.