### PR TITLE
replace '../staging' path by getDirectory() value

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "vpeltot/content_staging",
+  "name": "Eurelis/content_staging",
   "description": "A drupal module to keep content during site install.",
   "type": "drupal-module",
   "homepage": "https://github.com/vpeltot/content_staging",

--- a/src/ContentStagingImport.php
+++ b/src/ContentStagingImport.php
@@ -128,7 +128,7 @@ class ContentStagingImport {
         'migration_group' => 'content_staging',
         'source' => [
           'plugin' => 'content_staging_json',
-          'input_path' => '../staging/' . $entity_type_id . '/' . $language . '/' . $bundle_id . '.json',
+          'input_path' => $export_path . '/' . $entity_type_id . '/' . $language . '/' . $bundle_id . '.json',
         ],
         'process' => $process['process_definition'],
         'destination' => [

--- a/src/Plugin/migrate/source/ContentStagingJson.php
+++ b/src/Plugin/migrate/source/ContentStagingJson.php
@@ -133,7 +133,11 @@ class ContentStagingJson extends SourcePluginBase {
       }
 
       if ($key == 'uri') {
-        $row->setSourceProperty('filepath', realpath('../staging/files') . '/' . str_replace('public://', '', $value));
+        // We need the content_staging.manager service to get the staging path
+        /* @var \Drupal\content_staging\ContentStagingManager $content_staging_manager */
+        $content_staging_manager = \Drupal::service('content_staging.manager');
+
+        $row->setSourceProperty('filepath', realpath($content_staging_manager->getDirectory() . '/files') . '/' . str_replace('public://', '', $value));
       }
 
       if (empty($item)) {


### PR DESCRIPTION
Il restait 2 utilisations "en dur" du chemin "../staging" non surchargés par la configuration.
Cela empêchait le ré-import des images lorsque l'on surcharge le chemin dans la configuration.